### PR TITLE
Add repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MPL-2.0"
 keywords = ["apt", "async", "tokio", "debian"]
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
+repository = "https://github.com/pop-os/apt-cmd"
 
 [dependencies]
 anyhow = "1.0.66"


### PR DESCRIPTION
This information is missing on the crates.io website, so I had a hard time finding this repository (at least harder than it has to be).
