### PR TITLE
Fix: Add features to pass through to async-fetcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,5 @@ version = "1.21.2"
 features = ["full"]
 
 [features]
+isahc = ["async-fetcher/isahc"]
+reqwest = ["async-fetcher/reqwest"]


### PR DESCRIPTION
I cannot compile `master` without this patch.