### PR TITLE
Make AptGet::stream_up{date, grade}() return Stream + Send

### DIFF
--- a/src/apt_get.rs
+++ b/src/apt_get.rs
@@ -23,7 +23,7 @@ pub struct BadPPA {
     pub pocket: String,
 }
 
-pub type UpgradeEvents = Pin<Box<dyn Stream<Item = AptUpgradeEvent>>>;
+pub type UpgradeEvents = Pin<Box<dyn Stream<Item = AptUpgradeEvent> + Send>>;
 
 #[derive(AsMut, Deref, DerefMut)]
 #[as_mut(forward)]
@@ -186,7 +186,7 @@ impl AptGet {
         Ok(Ok(packages))
     }
 
-    pub async fn stream_update(mut self) -> io::Result<Pin<Box<dyn Stream<Item = UpdateEvent>>>> {
+    pub async fn stream_update(mut self) -> io::Result<Pin<Box<dyn Stream<Item = UpdateEvent> + Send>>> {
         self.arg("update");
 
         let (mut child, stdout) = self.spawn_with_stdout().await?;


### PR DESCRIPTION
As the user of the library has to await both the stream and the child handle, it makes usage of the API a lot simpler if the returned `Stream` is also `Send`.