### PR TITLE
feat: Handle SHA256 & SHA512 hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ futures = "0.3.30"
 hex = "0.4.3"
 md-5 = "0.10.6"
 procfs = "0.16.0"
-sha-1 = "0.10.1"
 thiserror = "1.0.60"
 rayon = "1.10.0"
 deb-version = "0.1.1"
+sha1 = "0.10.6"
+sha2 = "0.10.9"
 
 [dependencies.tokio]
 version = "1.37.0"

--- a/src/request.rs
+++ b/src/request.rs
@@ -32,6 +32,8 @@ pub enum RequestError {
 pub enum RequestChecksum {
     Md5(String),
     Sha1(String),
+    Sha256(String),
+    Sha512(String),
 }
 
 #[derive(Debug, Clone, Eq)]
@@ -89,6 +91,10 @@ impl FromStr for Request {
             RequestChecksum::Md5(value.to_owned())
         } else if let Some(value) = checksum_string.strip_prefix("SHA1:") {
             RequestChecksum::Sha1(value.to_owned())
+        } else if let Some(value) = checksum_string.strip_prefix("SHA256:") {
+            RequestChecksum::Sha256(value.to_owned())
+        } else if let Some(value) = checksum_string.strip_prefix("SHA512:") {
+            RequestChecksum::Sha512(value.to_owned())
         } else {
             return Err(RequestError::UnknownChecksum(checksum_string.into()));
         };


### PR DESCRIPTION
The sha-1 crate currently in use is [deprecated](https://docs.rs/crate/sha-1/latest), so I replaced it with its successor.

The new sha256/sha512 functionality may be required for https://github.com/pop-os/upgrade/pull/354. Even if it doesn't turn out we need it for that particular PR, apt [supports all of these algorithms](https://wiki.debian.org/DebianRepository/Format#Size.2C_MD5sum.2C_SHA1.2C_SHA256.2C_SHA512), so it seems like a good idea for apt-cmd to also support them.